### PR TITLE
Images filemask

### DIFF
--- a/data/ui/index.html
+++ b/data/ui/index.html
@@ -135,6 +135,25 @@
         </table>
       </fieldset>
     </div>
+
+    <fieldset style="margin-bottom: 55px">
+      <legend>File mask</legend>
+      <table width=100%>
+        <colgroup>
+          <col width="100">
+        </colgroup>
+        <tbody>
+          <tr>
+            <td>
+              <div hbox>
+                <input type="text" id="file-mask" value="" placeholder="[name] - [jobIndex][extension]" flex="1">
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </fieldset>
+
     <div hbox>
       <fieldset flex=1>
         <legend>Regular Expressions</legend>

--- a/data/ui/index.html
+++ b/data/ui/index.html
@@ -145,8 +145,15 @@
         <tbody>
           <tr>
             <td>
+              <p>You can use filemask to rename the output files however you want. You will need to put the desired output inside closed brackets for it to work, e.g.:</p>
+              <code>[attribute1][attribute2] - [attribute3]</code>
+              <p>Available attributes: <b>name</b>, <b>type</b>, <b>disposition</b>, <b>extension</b>, <b>order</b>, <b>index</b>.</p>
+            </td>
+          </tr>
+          <tr>
+            <td>
               <div hbox>
-                <input type="text" id="file-mask" value="" placeholder="[name] - [jobIndex][extension]" flex="1">
+                <input type="text" id="file-mask" value="" placeholder="[name][extension]" flex="1">
               </div>
             </td>
           </tr>

--- a/data/ui/index.js
+++ b/data/ui/index.js
@@ -28,6 +28,9 @@ var elements = {
     origin: document.getElementById('group-origin'),
     identical: document.getElementById('group-identical')
   },
+  files: {
+    mask: document.getElementById('file-mask')
+  },
   save: {
     directory: document.getElementById('custom-directory'),
     format: document.getElementById('format'),
@@ -83,11 +86,13 @@ function validate(name) {
 function build() {
   const custom = elements.save.directory.value.replace(/[\\\\/:*?"<>|]/g, '_');
   let filename = elements.save.filename.value;
+  let fileMask = elements.file.mask.value;
   filename = validate(filename);
   filename = custom ? custom + '/' + filename : filename;
 
   return {
     filename,
+    fileMask,
     addJPG: elements.type.noType.checked,
     images: filtered(),
     saveAs: elements.save.dialog.checked

--- a/data/ui/index.js
+++ b/data/ui/index.js
@@ -86,7 +86,7 @@ function validate(name) {
 function build() {
   const custom = elements.save.directory.value.replace(/[\\\\/:*?"<>|]/g, '_');
   let filename = elements.save.filename.value;
-  let fileMask = elements.file.mask.value;
+  let fileMask = elements.files.mask.value;
   filename = validate(filename);
   filename = custom ? custom + '/' + filename : filename;
 

--- a/save-images.js
+++ b/save-images.js
@@ -177,7 +177,7 @@ Download.prototype.download = function(obj, jobIndex) {
             type,
             disposition,
             extension,
-            jobIndex,
+            order: jobIndex,
             index: indices[name],
           };
 


### PR DESCRIPTION
Addresses https://github.com/belaviyo/save-images/issues/18

This feature adds a specific field in the popup UI for naming the output files using a filemask, i.e.

`[order] - TODAY[extension]`

Assuming the filter has 20 images, the resulting zip would look like this.

```
1 - TODAY.png
2 - TODAY.gif
3 - TODAY.png
4 - TODAY.png
...
...
20 - TODAY.png
```

---

It also adds instructions for using the filemask.

![image](https://user-images.githubusercontent.com/17429390/46610133-3a09b580-cae0-11e8-88d7-907f102f6dd7.png)