### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/v2/data/gallery/index.js
+++ b/v2/data/gallery/index.js
@@ -131,9 +131,9 @@ document.addEventListener('click', e => {
       if (index === -1) {
         index = input.value.length;
       }
-      const extension = (input.value.substr(index) || '').substr(0, 10);
+      const extension = (input.value.slice(index) || '').slice(0, 10);
       const name = pattern
-        .replace(/\[#=*\d*\]/gi, ('000000' + (i + offset)).substr(o))
+        .replace(/\[#=*\d*\]/gi, ('000000' + (i + offset)).slice(o))
         .replace(/\[extension\]/gi, extension);
       input.value = name;
       input.dispatchEvent(new Event('input'));

--- a/v2/data/ui/guess.js
+++ b/v2/data/ui/guess.js
@@ -36,7 +36,7 @@ function guess(img, mask, noType = true) {
     for (const ext of ['jpeg', 'jpg', 'png', 'gif', 'bmp', 'webp']) {
       const i = page.toLowerCase().indexOf('.' + ext);
       if (i !== -1 && size > 500 * 1024) {
-        name = page.substr(0, i).split('/').pop();
+        name = page.slice(0, i).split('/').pop();
         break;
       }
     }
@@ -74,11 +74,11 @@ function guess(img, mask, noType = true) {
   if (index === -1) {
     index = name.length;
   }
-  let extension = name.substr(index).substr(0, 10);
+  let extension = name.slice(index).slice(0, 10);
   if (extension.length == 0 && noType) {
     extension = '.jpg';
   }
-  name = name.substr(0, index);
+  name = name.slice(0, index);
   if (name.startsWith('%')) {
     name = decodeURIComponent(name);
   }
@@ -103,7 +103,7 @@ function guess(img, mask, noType = true) {
     // make sure filename is acceptable
     .replace(/[`~!@#$%^&*()|+=?;:'",.<>{}[\]\\/]/gi, '-')
     // limit length of each section to 60 chars
-    .substr(0, 60)).join(extension);
+    .slice(0, 60)).join(extension);
 
   return {
     filename,

--- a/v2/inzip.js
+++ b/v2/inzip.js
@@ -168,7 +168,7 @@ class InZIP {
     crc = crc ^ (-1);
     for (let i = 0, iTop = uint8a.byteLength; i < iTop; i++) {
       y = (crc ^ uint8a[i]) & 0xFF;
-      x = '0x' + this.config.CRCTables.substr(y * 9, 8);
+      x = '0x' + this.config.CRCTables.slice(y * 9, y * 9 + 8);
       crc = (crc >>> 8) ^ x;
     }
     return crc ^ (-1);

--- a/v3/data/gallery/index.js
+++ b/v3/data/gallery/index.js
@@ -133,9 +133,9 @@ document.addEventListener('click', e => {
       if (index === -1) {
         index = input.value.length;
       }
-      const extension = (input.value.substr(index) || '').substr(0, 10);
+      const extension = (input.value.slice(index) || '').slice(0, 10);
       const name = pattern
-        .replace(/\[#=*\d*\]/gi, ('000000' + (i + offset)).substr(o))
+        .replace(/\[#=*\d*\]/gi, ('000000' + (i + offset)).slice(o))
         .replace(/\[extension\]/gi, extension);
       input.value = name;
       input.dispatchEvent(new Event('input'));

--- a/v3/data/inject/core/inzip.js
+++ b/v3/data/inject/core/inzip.js
@@ -168,7 +168,7 @@ class InZIP {
     crc = crc ^ (-1);
     for (let i = 0, iTop = uint8a.byteLength; i < iTop; i++) {
       y = (crc ^ uint8a[i]) & 0xFF;
-      x = '0x' + this.config.CRCTables.substr(y * 9, 8);
+      x = '0x' + this.config.CRCTables.slice(y * 9, y * 9 + 8);
       crc = (crc >>> 8) ^ x;
     }
     return crc ^ (-1);

--- a/v3/data/size.js
+++ b/v3/data/size.js
@@ -10,7 +10,7 @@ var hex = (uint8a, start, end) => {
 // https://github.com/image-size/image-size/blob/main/lib/types/png.ts
 type.png = uint8a => {
   const b = String.fromCharCode(...uint8a.slice(0, 10));
-  if (b.substr(1, 7) === 'PNG\r\n\x1a\n') {
+  if (b.slice(1, 8) === 'PNG\r\n\x1a\n') {
     return true;
   }
 
@@ -20,7 +20,7 @@ size.png = uint8a => {
   const b = String.fromCharCode(...uint8a.slice(0, 40));
   const view = new DataView(uint8a.buffer);
 
-  if (b.substr(12, 4) === 'CgBI') {
+  if (b.slice(12, 16) === 'CgBI') {
     return {
       type: 'image/png',
       width: view.getUint32(36, false),
@@ -68,9 +68,9 @@ size.bmp = uint8a => {
 // https://github.com/image-size/image-size/blob/main/lib/types/webp.ts
 type.webp = uint8a => {
   const b = String.fromCharCode(...uint8a.slice(0, 16));
-  const riffHeader = 'RIFF' === b.substr(0, 4);
-  const webpHeader = 'WEBP' === b.substr(8, 4);
-  const vp8Header = 'VP8' === b.substr(12, 3);
+  const riffHeader = 'RIFF' === b.slice(0, 4);
+  const webpHeader = 'WEBP' === b.slice(8, 12);
+  const vp8Header = 'VP8' === b.slice(12, 15);
 
   return (riffHeader && webpHeader && vp8Header);
 };

--- a/v3/data/utils.js
+++ b/v3/data/utils.js
@@ -41,7 +41,7 @@ self.utils = {
       for (const ext of ['jpeg', 'jpg', 'png', 'gif', 'bmp', 'webp']) {
         const i = page.toLowerCase().indexOf('.' + ext);
         if (i !== -1 && size > 500 * 1024) {
-          name = page.substr(0, i).split('/').pop();
+          name = page.slice(0, i).split('/').pop();
           break;
         }
       }
@@ -79,11 +79,11 @@ self.utils = {
     if (index === -1) {
       index = name.length;
     }
-    let extension = name.substr(index).substr(0, 10);
+    let extension = name.slice(index).slice(0, 10);
     if (extension.length == 0 && noType) {
       extension = '.jpg';
     }
-    name = name.substr(0, index);
+    name = name.slice(0, index);
     if (name.startsWith('%')) {
       name = decodeURIComponent(name);
     }
@@ -110,7 +110,7 @@ self.utils = {
       // make sure filename is acceptable
       str = self.utils.rename(str);
       // limit length of each section to 60 chars
-      str = str.substr(0, 60);
+      str = str.slice(0, 60);
 
       return str;
     }).join(extension);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.